### PR TITLE
Improve camera source handling

### DIFF
--- a/modules/person_tracker.py
+++ b/modules/person_tracker.py
@@ -181,6 +181,19 @@ class PersonTracker:
         width = height = None
         if self.resolution != "original":
             width, height = res_map.get(self.resolution, (None, None))
+        if self.src_type == "local":
+            try:
+                index = int(self.src) if str(self.src).isdigit() else self.src
+            except ValueError:
+                index = self.src
+            cap = cv2.VideoCapture(index)
+            if self.resolution != "original" and self.resolution in res_map:
+                w, h = res_map[self.resolution]
+                cap.set(cv2.CAP_PROP_FRAME_WIDTH, w)
+                cap.set(cv2.CAP_PROP_FRAME_HEIGHT, h)
+            logger.info(f"[{self.cam_id}] Using cv2.VideoCapture (local)")
+            return cap
+
         try:
             cap = FFmpegCameraStream(self.src, width, height)
             if cap.isOpened():
@@ -189,14 +202,8 @@ class PersonTracker:
             logger.warning(f"[{self.cam_id}] FFmpeg stream failed, falling back to cv2")
         except Exception as e:
             logger.error(f"[{self.cam_id}] FFmpeg init error: {e}; falling back to cv2")
-        if self.src_type == "local":
-            try:
-                index = int(self.src)
-            except ValueError:
-                index = self.src
-            cap = cv2.VideoCapture(index)
-        else:
-            cap = cv2.VideoCapture(self.src)
+
+        cap = cv2.VideoCapture(self.src)
         if self.resolution != "original" and self.resolution in res_map:
             w, h = res_map[self.resolution]
             cap.set(cv2.CAP_PROP_FRAME_WIDTH, w)

--- a/routers/cameras.py
+++ b/routers/cameras.py
@@ -8,6 +8,7 @@ from fastapi.templating import Jinja2Templates
 from fastapi.responses import RedirectResponse
 from modules.utils import require_roles
 import cv2
+from modules.ffmpeg_stream import FFmpegCameraStream
 
 from core.tracker_manager import start_tracker, stop_tracker, save_cameras
 from core.config import CAMERA_TASKS
@@ -58,6 +59,10 @@ async def add_camera(request: Request):
         tasks = ['in_count', 'out_count']
     if not url:
         return {'error': 'Missing URL'}
+    if url.isdigit() or url.startswith('/dev/'):
+        src_type = 'local'
+    elif url.startswith('rtsp://'):
+        src_type = 'rtsp'
     cam_id = max([c['id'] for c in cams], default=0) + 1
     cam = {
         'id': cam_id,
@@ -115,6 +120,13 @@ async def update_camera(cam_id: int, request: Request):
                 cam['tasks'] = tasks_upd
             if 'url' in data:
                 cam['url'] = data['url']
+                if 'type' not in data:
+                    if cam['url'].isdigit() or cam['url'].startswith('/dev/'):
+                        cam['type'] = 'local'
+                    elif cam['url'].startswith('rtsp://'):
+                        cam['type'] = 'rtsp'
+                    else:
+                        cam['type'] = 'http'
             if 'type' in data:
                 cam['type'] = data['type']
             if 'show' in data:
@@ -176,9 +188,14 @@ async def test_camera(request: Request):
     url = data.get('url')
     if not url:
         return {'error': 'missing url'}
-    cap = cv2.VideoCapture(int(url) if url.isdigit() else url)
-    ret, frame = cap.read()
-    cap.release()
+    if url.isdigit() or url.startswith('/dev/'):
+        cap = cv2.VideoCapture(int(url) if url.isdigit() else url)
+        ret, frame = cap.read()
+        cap.release()
+    else:
+        cap = FFmpegCameraStream(url)
+        ret, frame = cap.read()
+        cap.release()
     if not ret:
         return {'error': 'unable to read'}
     _, buf = cv2.imencode('.jpg', frame)


### PR DESCRIPTION
## Summary
- detect camera type when adding or updating a camera
- open local sources directly with OpenCV in `PersonTracker`
- use FFmpeg only for network streams
- update preview endpoint to use FFmpeg for network streams

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e5879b74832a817824445ca65d5d